### PR TITLE
AUI-3182 In Calendar's monthly view, when today's date is the first day of the week, the blue border is cut out

### DIFF
--- a/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
@@ -171,6 +171,10 @@
     border-bottom-width: 0;
 }
 
+.scheduler-view-table-grid:first-child .scheduler-view-table-colgrid-today {
+    border-left: 1px solid #009be6;
+}
+
 .scheduler-view-table-row:last-child .scheduler-view-table-colgrid-today {
     border-bottom-width: 1px;
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-3182
Previous pr: https://github.com/liferay/alloy-ui/pull/159 -> Not the correct selectors.

Left blue border of today's date is cut out when it is the first day of the week. 

The fix makes the left border above when it is the first day of the week and today's date.